### PR TITLE
Set animation controller value to 1 when widget is checked

### DIFF
--- a/lib/src/msh_checkbox.dart
+++ b/lib/src/msh_checkbox.dart
@@ -88,6 +88,14 @@ class _MSHCheckboxState extends State<MSHCheckbox>
   }
 
   @override
+  void initState() {
+    super.initState();
+    if (widget.value) {
+      animationController.value = 1;
+    }
+  }
+
+  @override
   void didUpdateWidget(covariant MSHCheckbox oldWidget) {
     super.didUpdateWidget(oldWidget);
 


### PR DESCRIPTION
A simple yet stylish Widget, good work!

This fixes a little bit of an oversight I noticed: when a checkbox is instantiated with `value: true` it should be built checked, without the need of passing a new value to `value` to trigger `animationController.forward`.