### PR TITLE
Add label of checkbox & set default value of checked color from theme

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,6 +29,24 @@ class _MyAppState extends State<MyApp> {
         appBar: AppBar(title: const Text('MSHCheckbox Example')),
         body: Column(
           children: [
+            const SizedBox(height: 12),
+            Center(
+              child: MSHCheckbox(
+                label: 'Lorem ipsum dolor sit amets',
+                value: isChecked,
+                isDisabled: isDisabled,
+                colorConfig: MSHColorConfig.fromCheckedUncheckedDisabled(
+                  checkedColor: Colors.green,
+                  uncheckedColor: Colors.grey.shade600,
+                ),
+                style: style,
+                onChanged: (selected) {
+                  setState(() {
+                    isChecked = selected;
+                  });
+                },
+              ),
+            ),
             Expanded(
               child: Center(
                 child: MSHCheckbox(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,7 +32,14 @@ class _MyAppState extends State<MyApp> {
             const SizedBox(height: 12),
             Center(
               child: MSHCheckbox(
-                label: 'Lorem ipsum dolor sit amets',
+                label: (checked) => Text(
+                  'Lorem ipsum dolor sit amets',
+                  style: TextStyle(
+                    decoration: checked ? TextDecoration.lineThrough : null,
+                    color: checked ? Colors.black45 : null,
+                  ),
+                ),
+                allowTapOnLabel: true,
                 value: isChecked,
                 isDisabled: isDisabled,
                 colorConfig: MSHColorConfig.fromCheckedUncheckedDisabled(

--- a/lib/src/checkboxes/msh_checkbox_base.dart
+++ b/lib/src/checkboxes/msh_checkbox_base.dart
@@ -7,26 +7,29 @@ import 'package:msh_checkbox/src/checkboxes/stroke_checkbox.dart';
 import 'package:msh_checkbox/src/msh_checkbox_state.dart';
 
 class MSHCheckboxBase extends StatelessWidget {
-  final MSHCheckboxStyle style;
-  final bool isDisabled;
-  final MSHColorConfig colorConfig;
   final Animation<double> animation;
-  final double strokeWidth;
+  final BuildContext context;
+  final MSHCheckboxStyle style;
+  final MSHColorConfig colorConfig;
+  final bool isDisabled;
   final double size;
+  final double strokeWidth;
 
   MSHCheckboxState get state => MSHCheckboxState(
+        context: context,
         isDisabled: isDisabled,
         style: style,
       );
 
   const MSHCheckboxBase({
     Key? key,
-    required this.style,
-    required this.isDisabled,
-    required this.colorConfig,
     required this.animation,
-    required this.strokeWidth,
+    required this.colorConfig,
+    required this.context,
+    required this.isDisabled,
     required this.size,
+    required this.strokeWidth,
+    required this.style,
   }) : super(key: key);
 
   @override

--- a/lib/src/msh_checkbox.dart
+++ b/lib/src/msh_checkbox.dart
@@ -28,7 +28,7 @@ class MSHCheckbox extends StatefulWidget {
     @Deprecated("Use MSHColorConfig.fromCheckedUncheckedDisabled instead.")
         this.disabledColor = const Color(0xFFCCCCCC),
     MSHColorConfig? colorConfig,
-    this.size = 18,
+    this.size = 20,
     this.duration,
     this.style = MSHCheckboxStyle.stroke,
     required this.onChanged,
@@ -197,9 +197,9 @@ class _MSHCheckboxState extends State<MSHCheckbox>
         children: [
           checkbox,
           SizedBox(width: widget.labelSpacing),
-          GestureDetector(
-            onTap: () => widget.allowTapOnLabel ? _toggleCheckbox() : null,
-            child: Flexible(
+          Flexible(
+            child: GestureDetector(
+              onTap: () => widget.allowTapOnLabel ? _toggleCheckbox() : null,
               child: widget.label!(widget.value),
             ),
           ),

--- a/lib/src/msh_checkbox.dart
+++ b/lib/src/msh_checkbox.dart
@@ -19,7 +19,7 @@ class MSHCheckbox extends StatefulWidget {
     required this.value,
     this.isDisabled = false,
     @Deprecated("Use MSHColorConfig.fromCheckedUncheckedDisabled instead.")
-        this.checkedColor = Colors.blue,
+        this.checkedColor,
     @Deprecated("Use MSHColorConfig.fromCheckedUncheckedDisabled instead.")
         this.uncheckedColor = const Color(0xFFCCCCCC),
     @Deprecated("Use MSHColorConfig.fromCheckedUncheckedDisabled instead.")
@@ -46,7 +46,7 @@ class MSHCheckbox extends StatefulWidget {
   /// The color of the checkbox when [value] is `true`. If [colorConfig] is
   /// specified, this value will be overridden by [MSHColorConfig.onFillColor].
   @Deprecated("Use MSHColorConfig.fromCheckedUncheckedDisabled instead.")
-  final Color checkedColor;
+  final Color? checkedColor;
 
   /// The color of the checkbox when [value] is `false`. If [colorConfig] is
   /// specified, this value will be overridden by [MSHColorConfig.offTintColor].
@@ -130,6 +130,7 @@ class _MSHCheckboxState extends State<MSHCheckbox>
   @override
   Widget build(BuildContext context) {
     final state = MSHCheckboxState(
+      context: context,
       isDisabled: widget.isDisabled,
       style: widget.style,
     );
@@ -162,6 +163,7 @@ class _MSHCheckboxState extends State<MSHCheckbox>
               minWidth: widget.size,
             ),
             child: MSHCheckboxBase(
+              context: context,
               style: widget.style,
               isDisabled: widget.isDisabled,
               colorConfig: widget.colorConfig,

--- a/lib/src/msh_checkbox.dart
+++ b/lib/src/msh_checkbox.dart
@@ -25,7 +25,7 @@ class MSHCheckbox extends StatefulWidget {
     @Deprecated("Use MSHColorConfig.fromCheckedUncheckedDisabled instead.")
         this.disabledColor = const Color(0xFFCCCCCC),
     MSHColorConfig? colorConfig,
-    this.size = 40,
+    this.size = 18,
     this.duration,
     this.style = MSHCheckboxStyle.stroke,
     required this.onChanged,

--- a/lib/src/msh_checkbox.dart
+++ b/lib/src/msh_checkbox.dart
@@ -19,7 +19,7 @@ class MSHCheckbox extends StatefulWidget {
     required this.value,
     this.label,
     this.labelSpacing = 12,
-    this.labelStyle,
+    this.allowTapOnLabel = false,
     this.isDisabled = false,
     @Deprecated("Use MSHColorConfig.fromCheckedUncheckedDisabled instead.")
         this.checkedColor,
@@ -78,13 +78,13 @@ class MSHCheckbox extends StatefulWidget {
   final void Function(bool selected) onChanged;
 
   /// Label of checkbox
-  final String? label;
-
-  /// Text stye of label checkbox
-  final TextStyle? labelStyle;
+  final Widget Function(bool checked)? label;
 
   /// Spacing between checkbox and label
   final double labelSpacing;
+
+  /// Allow changing the state when label is tapped
+  final bool allowTapOnLabel;
 
   @override
   State<MSHCheckbox> createState() => _MSHCheckboxState();
@@ -139,6 +139,12 @@ class _MSHCheckboxState extends State<MSHCheckbox>
     }
   }
 
+  void _toggleCheckbox() {
+    if (!widget.isDisabled) {
+      widget.onChanged(!widget.value);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final state = MSHCheckboxState(
@@ -148,11 +154,7 @@ class _MSHCheckboxState extends State<MSHCheckbox>
     );
 
     final checkbox = GestureDetector(
-      onTap: () {
-        if (!widget.isDisabled) {
-          widget.onChanged(!widget.value);
-        }
-      },
+      onTap: _toggleCheckbox,
       child: Stack(
         alignment: Alignment.center,
         children: [
@@ -195,10 +197,10 @@ class _MSHCheckboxState extends State<MSHCheckbox>
         children: [
           checkbox,
           SizedBox(width: widget.labelSpacing),
-          Flexible(
-            child: Text(
-              widget.label!,
-              style: widget.labelStyle,
+          GestureDetector(
+            onTap: () => widget.allowTapOnLabel ? _toggleCheckbox() : null,
+            child: Flexible(
+              child: widget.label!(widget.value),
             ),
           ),
         ],

--- a/lib/src/msh_checkbox.dart
+++ b/lib/src/msh_checkbox.dart
@@ -17,6 +17,9 @@ class MSHCheckbox extends StatefulWidget {
   MSHCheckbox({
     Key? key,
     required this.value,
+    this.label,
+    this.labelSpacing = 12,
+    this.labelStyle,
     this.isDisabled = false,
     @Deprecated("Use MSHColorConfig.fromCheckedUncheckedDisabled instead.")
         this.checkedColor,
@@ -73,6 +76,15 @@ class MSHCheckbox extends StatefulWidget {
 
   /// Called when the value of the checkbox should change.
   final void Function(bool selected) onChanged;
+
+  /// Label of checkbox
+  final String? label;
+
+  /// Text stye of label checkbox
+  final TextStyle? labelStyle;
+
+  /// Spacing between checkbox and label
+  final double labelSpacing;
 
   @override
   State<MSHCheckbox> createState() => _MSHCheckboxState();
@@ -135,7 +147,7 @@ class _MSHCheckboxState extends State<MSHCheckbox>
       style: widget.style,
     );
 
-    return GestureDetector(
+    final checkbox = GestureDetector(
       onTap: () {
         if (!widget.isDisabled) {
           widget.onChanged(!widget.value);
@@ -175,6 +187,25 @@ class _MSHCheckboxState extends State<MSHCheckbox>
         ],
       ),
     );
+
+    if (widget.label != null) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          checkbox,
+          SizedBox(width: widget.labelSpacing),
+          Flexible(
+            child: Text(
+              widget.label!,
+              style: widget.labelStyle,
+            ),
+          ),
+        ],
+      );
+    } else {
+      return checkbox;
+    }
   }
 
   @override

--- a/lib/src/msh_checkbox_state.dart
+++ b/lib/src/msh_checkbox_state.dart
@@ -1,10 +1,13 @@
+import 'package:flutter/widgets.dart';
 import 'package:msh_checkbox/msh_checkbox.dart';
 
 class MSHCheckboxState {
+  final BuildContext context;
   final bool isDisabled;
   final MSHCheckboxStyle style;
 
   const MSHCheckboxState({
+    required this.context,
     required this.isDisabled,
     required this.style,
   });

--- a/lib/src/msh_checkbox_style.dart
+++ b/lib/src/msh_checkbox_style.dart
@@ -1,24 +1,24 @@
 /// The animation/style for an [MSHCheckbox].
 enum MSHCheckboxStyle {
-  /// Draws a circle and a checkmark inside.
+  /// Draws a circle and a check mark inside.
   stroke,
 
   /// Scales in the fill color (from the center) for the circle, while fading in the
-  /// checkmark.
+  /// check mark.
   ///
-  /// The fill color is given by [MSHCheckbox.checkedColor], and the checkmark
+  /// The fill color is given by [MSHCheckbox.checkedColor], and the check mark
   /// will be colored white.
   fillScaleColor,
 
-  /// Fades in a filled circle, while scaling in the checkmark.
+  /// Fades in a filled circle, while scaling in the check mark.
   ///
-  /// The fill color is given by [MSHCheckbox.checkedColor], and the checkmark
+  /// The fill color is given by [MSHCheckbox.checkedColor], and the check mark
   /// will be colored white.
   fillScaleCheck,
 
-  /// Fades in both a filled circle and a checkmark - No scaling animation.
+  /// Fades in both a filled circle and a check mark - No scaling animation.
   ///
-  /// The fill color is given by [MSHCheckbox.checkedColor], and the checkmark
+  /// The fill color is given by [MSHCheckbox.checkedColor], and the check mark
   /// will be colored white.
   fillFade,
 }

--- a/lib/src/msh_color_config.dart
+++ b/lib/src/msh_color_config.dart
@@ -18,7 +18,7 @@ class MSHColorConfig {
   /// The background fill color for the checkbox when [MSHCheckbox.value] is `true`.
   final ColorFromState fillColor;
 
-  /// The color of the checkmark.
+  /// The color of the check mark.
   final ColorFromState checkColor;
 
   /// Construct an MSHColorConfig

--- a/lib/src/msh_color_config.dart
+++ b/lib/src/msh_color_config.dart
@@ -35,7 +35,7 @@ class MSHColorConfig {
   /// Presents a simplified interface for constructing an [MSHColorConfig].
   factory MSHColorConfig.fromCheckedUncheckedDisabled({
     /// The color of the check and border or fill when [MSHCheckbox.value] is `true`.
-    Color checkedColor = Colors.blue,
+    Color? checkedColor,
 
     /// The color of the checkbox when [MSHCheckbox.value] is `false`.
     Color uncheckedColor = const Color(0xFFCCCCCC),
@@ -46,11 +46,18 @@ class MSHColorConfig {
       MSHColorConfig(
         borderColor: (state) =>
             state.isDisabled ? disabledColor : uncheckedColor,
-        tintColor: (state) => state.isDisabled ? disabledColor : checkedColor,
-        fillColor: (state) => state.isDisabled ? disabledColor : checkedColor,
+        tintColor: (state) => state.isDisabled
+            ? disabledColor
+            : (checkedColor ?? Theme.of(state.context).toggleableActiveColor),
+        fillColor: (state) => state.isDisabled
+            ? disabledColor
+            : (checkedColor ?? Theme.of(state.context).toggleableActiveColor),
         checkColor: (state) {
           if (state.style == MSHCheckboxStyle.stroke) {
-            return state.isDisabled ? disabledColor : checkedColor;
+            return state.isDisabled
+                ? disabledColor
+                : (checkedColor ??
+                    Theme.of(state.context).toggleableActiveColor);
           } else {
             return Colors.white;
           }
@@ -62,16 +69,16 @@ class MSHColorConfig {
   }
 
   static Color _defaultTintColor(MSHCheckboxState state) {
-    return Colors.blue;
+    return Theme.of(state.context).toggleableActiveColor;
   }
 
   static Color _defaultFillColor(MSHCheckboxState state) {
-    return Colors.blue;
+    return Theme.of(state.context).toggleableActiveColor;
   }
 
   static Color _defaultCheckColor(MSHCheckboxState state) {
     if (state.style == MSHCheckboxStyle.stroke) {
-      return Colors.blue;
+      return Theme.of(state.context).toggleableActiveColor;
     } else {
       return Colors.white;
     }


### PR DESCRIPTION
I added new field `label` to make it easier for create widget such as for approving terms and conditions or todo apps (which I use your widget for it), and I added an initial value for `checkedColor` based on the theme